### PR TITLE
Improve README for Decision Spinner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,23 @@
-# spinner
+# Decision Spinner
 
-A new Flutter project.
+Decision Spinner is a simple Flutter application for making random choices. The app presents a fortune-style wheel that you can spin to help decide between multiple options. Use one of the built–in wheels for quick decisions or create your own custom wheel with as many items as you like.
+
+## Features
+
+- Predefined wheels for common questions such as "Should I?", choosing a drink or food, and selecting a cuisine.
+- Create a new wheel with custom items and colors.
+- Spin the wheel to randomly pick an item and display the result.
 
 ## Getting Started
 
-This project is a starting point for a Flutter application.
+1. Install [Flutter](https://flutter.dev/docs/get-started/install) on your development machine.
+2. Fetch the project dependencies with:
+   ```
+   flutter pub get
+   ```
+3. Run the application on an emulator or connected device:
+   ```
+   flutter run
+   ```
 
-A few resources to get you started if this is your first Flutter project:
-
-- [Lab: Write your first Flutter app](https://flutter.dev/docs/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://flutter.dev/docs/cookbook)
-
-For help getting started with Flutter, view our
-[online documentation](https://flutter.dev/docs), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+Have fun spinning!


### PR DESCRIPTION
## Summary
- rewrite README to explain the Decision Spinner app
- remove boilerplate Flutter template text

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849970b11f88330afde9b578b04bfa2