### PR TITLE
Fix typo in home menu title constant

### DIFF
--- a/lib/utils/constants/list_constants.dart
+++ b/lib/utils/constants/list_constants.dart
@@ -87,7 +87,7 @@ WheelModel foodsWheelModel =
 
 List<HomeMenuItemModel> homeMenuItems = [
   HomeMenuItemModel(
-      title: sholdITitle, navigatePageName: WheelPage(shouldWheelModel)),
+      title: shouldITitle, navigatePageName: WheelPage(shouldWheelModel)),
   HomeMenuItemModel(
       title: drinksTitle, navigatePageName: WheelPage(drinksWheelModel)),
   HomeMenuItemModel(

--- a/lib/utils/constants/string_constants.dart
+++ b/lib/utils/constants/string_constants.dart
@@ -14,7 +14,7 @@ const String helveticaFontFamily = "HelveticaComp";
 const String poeFontFamily = "PoeNewBold";
 
 //Home Page Menu Button Titles
-const String sholdITitle = "SHOULD I ...?";
+const String shouldITitle = "SHOULD I ...?";
 const String drinksTitle = "DRINKS";
 const String foodsTitle = "FOODS";
 const String cuisinesTitle = "CUISINES";


### PR DESCRIPTION
## Summary
- rename `sholdITitle` to `shouldITitle`
- update references in list constants

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684998d457d48330ab75c11d4c5e60e9