### PR TITLE
Fix ad init callback

### DIFF
--- a/lib/views/wheel_page.dart
+++ b/lib/views/wheel_page.dart
@@ -32,9 +32,8 @@ class _WheelPageState extends State<WheelPage> {
     super.didChangeDependencies();
     final adState = Provider.of<AdState>(context);
     adState.initialization.then((status) {
-      setState(() {
-        adState.createInterstitialAd();
-      });
+      if (!mounted) return;
+      adState.createInterstitialAd();
     });
   }
 


### PR DESCRIPTION
## Summary
- ensure `didChangeDependencies` checks `mounted` before calling `createInterstitialAd`
- remove unnecessary `setState` call

## Testing
- `flutter analyze` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a835d6ad88330917b28ea1af66bf5